### PR TITLE
feat: add todo list components

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,34 +1,12 @@
-import { useState } from 'react';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
+import TodoList from './components/TodoList';
 import './App.css';
 
 function App() {
-  const [count, setCount] = useState(0);
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="App">
+      <h1>Todo App</h1>
+      <TodoList />
+    </div>
   );
 }
 

--- a/client/src/components/TodoItem.tsx
+++ b/client/src/components/TodoItem.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+
+export interface Task {
+  id: number;
+  title: string;
+  completed: boolean;
+}
+
+interface TodoItemProps {
+  task: Task;
+  onUpdate: (task: Task) => void;
+  onDelete: (id: number) => void;
+}
+
+function TodoItem({ task, onUpdate, onDelete }: TodoItemProps) {
+  const [editing, setEditing] = useState(false);
+  const [title, setTitle] = useState(task.title);
+
+  const toggleCompleted = async () => {
+    try {
+      const res = await fetch(`/tasks/${task.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ completed: !task.completed }),
+      });
+      if (res.ok) {
+        onUpdate({ ...task, completed: !task.completed });
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const saveTitle = async () => {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      setTitle(task.title);
+      setEditing(false);
+      return;
+    }
+    try {
+      const res = await fetch(`/tasks/${task.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: trimmed }),
+      });
+      if (res.ok) {
+        const updated: Task = await res.json();
+        onUpdate(updated);
+        setEditing(false);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const deleteTask = async () => {
+    try {
+      const res = await fetch(`/tasks/${task.id}`, { method: 'DELETE' });
+      if (res.ok) {
+        onDelete(task.id);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <li>
+      <input
+        type="checkbox"
+        checked={task.completed}
+        onChange={toggleCompleted}
+      />
+      {editing ? (
+        <>
+          <input value={title} onChange={(e) => setTitle(e.target.value)} />
+          <button onClick={saveTitle}>Save</button>
+        </>
+      ) : (
+        <span
+          onDoubleClick={() => setEditing(true)}
+          style={{
+            textDecoration: task.completed ? 'line-through' : undefined,
+          }}
+        >
+          {task.title}
+        </span>
+      )}
+      <button onClick={deleteTask}>Delete</button>
+    </li>
+  );
+}
+
+export default TodoItem;

--- a/client/src/components/TodoList.tsx
+++ b/client/src/components/TodoList.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import TodoItem, { Task } from './TodoItem';
+
+function TodoList() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [newTitle, setNewTitle] = useState('');
+
+  const loadTasks = async () => {
+    try {
+      const res = await fetch('/tasks');
+      if (res.ok) {
+        const data: Task[] = await res.json();
+        setTasks(data);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    loadTasks();
+  }, []);
+
+  const addTask = async () => {
+    const title = newTitle.trim();
+    if (!title) return;
+    try {
+      const res = await fetch('/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title }),
+      });
+      if (res.ok) {
+        const task: Task = await res.json();
+        setTasks((prev) => [...prev, task]);
+        setNewTitle('');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const updateTask = (updated: Task) => {
+    setTasks((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+  };
+
+  const deleteTask = (id: number) => {
+    setTasks((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  return (
+    <div>
+      <h2>Todo List</h2>
+      <div>
+        <input
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          placeholder="New task"
+        />
+        <button onClick={addTask}>Add</button>
+      </div>
+      <ul>
+        {tasks.map((task) => (
+          <TodoItem
+            key={task.id}
+            task={task}
+            onUpdate={updateTask}
+            onDelete={deleteTask}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default TodoList;


### PR DESCRIPTION
## Summary
- implement todo list and item components with CRUD operations via fetch
- render todo list in main app

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f1bd07dcc832f86a23a7e56fa72f5