### PR TITLE
docs: add containerization and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install dependencies
+        run: |
+          cd server && npm ci
+          cd ../client && npm ci
+      - name: Run server tests
+        run: |
+          cd server && npm test
+      - name: Run client tests
+        run: |
+          cd client && npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Multi-stage build for AIHubX
+
+# Build server
+FROM node:18-alpine AS server-build
+WORKDIR /app/server
+COPY server/package*.json ./
+RUN npm ci
+COPY server/ ./
+RUN npm run build
+
+# Build client
+FROM node:18-alpine AS client-build
+WORKDIR /app/client
+COPY client/package*.json ./
+RUN npm ci
+COPY client/ ./
+RUN npm run build
+
+# Production image
+FROM node:18-alpine
+WORKDIR /app
+# copy server build output
+COPY --from=server-build /app/server/dist ./dist
+COPY --from=server-build /app/server/package*.json ./
+# install production deps
+RUN npm ci --omit=dev
+# copy built client assets into public directory
+COPY --from=client-build /app/client/dist ./public
+EXPOSE 3000
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -69,3 +69,42 @@
 - 通讯：WebSocket + REST API
 - 插件系统：基于模块热插拔的NPM模块
 - 部署：Docker + K8s 支持，CI/CD
+
+---
+
+## ⚙️ 安装
+
+```bash
+git clone https://github.com/yourname/AIHubX.git
+cd AIHubX
+cd server && npm install
+cd ../client && npm install
+```
+
+---
+
+## 🚀 使用示例
+
+### 本地运行
+
+启动后端服务：
+
+```bash
+cd server
+npm run dev
+```
+
+启动前端应用：
+
+```bash
+cd client
+npm run dev
+```
+
+### Docker Compose 部署
+
+```bash
+docker compose up --build
+```
+
+启动后访问 `http://localhost:3000` 即可。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - '3000:3000'
+    environment:
+      - NODE_ENV=production
+    depends_on:
+      - postgres
+      - redis
+  postgres:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: aihubx
+    volumes:
+      - db-data:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+    restart: always
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- document installation steps and local/docker usage
- add Dockerfile and docker-compose for container deployments
- configure GitHub Actions to run server and client tests

## Testing
- `npm test` in `server`
- `npm test` in `client`
- `docker-compose config`


------
https://chatgpt.com/codex/tasks/task_e_688f28441df8832f89ef513166ef2052