### PR TITLE
fix: resolve lint errors

### DIFF
--- a/client/src/components/TodoItem.test.tsx
+++ b/client/src/components/TodoItem.test.tsx
@@ -12,9 +12,7 @@ describe('TodoItem', () => {
   });
 
   test('renders task title', () => {
-    render(
-      <TodoItem task={task} onUpdate={vi.fn()} onDelete={vi.fn()} />,
-    );
+    render(<TodoItem task={task} onUpdate={vi.fn()} onDelete={vi.fn()} />);
     expect(screen.getByText('Test Task')).toBeInTheDocument();
   });
 
@@ -38,7 +36,9 @@ describe('TodoItem', () => {
     vi.stubGlobal('fetch', fetchMock);
     render(<TodoItem task={task} onUpdate={vi.fn()} onDelete={onDelete} />);
     await fireEvent.click(screen.getByText('Delete'));
-    expect(fetchMock).toHaveBeenCalledWith(`/tasks/${task.id}`, { method: 'DELETE' });
+    expect(fetchMock).toHaveBeenCalledWith(`/tasks/${task.id}`, {
+      method: 'DELETE',
+    });
     expect(onDelete).toHaveBeenCalledWith(task.id);
   });
 });

--- a/client/src/components/TodoList.test.tsx
+++ b/client/src/components/TodoList.test.tsx
@@ -10,7 +10,9 @@ afterEach(() => {
 
 test('loads and displays tasks', async () => {
   const tasks = [{ id: 1, title: 'Existing', completed: false }];
-  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => tasks });
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => tasks });
   vi.stubGlobal('fetch', fetchMock);
   render(<TodoList />);
   expect(await screen.findByText('Existing')).toBeInTheDocument();

--- a/server/eslint.config.mjs
+++ b/server/eslint.config.mjs
@@ -13,7 +13,10 @@ export default [
       parser: tsParser,
       ecmaVersion: 2020,
       sourceType: 'module',
-      globals: globals.node,
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
     },
     plugins: {
       '@typescript-eslint': tsPlugin,

--- a/server/src/routes/tasks.test.ts
+++ b/server/src/routes/tasks.test.ts
@@ -34,7 +34,9 @@ describe('tasks API', () => {
   });
 
   test('deletes a task', async () => {
-    const createRes = await request(app).post('/tasks').send({ title: 'to delete' });
+    const createRes = await request(app)
+      .post('/tasks')
+      .send({ title: 'to delete' });
     const id = createRes.body.id;
     const deleteRes = await request(app).delete(`/tasks/${id}`);
     expect(deleteRes.status).toBe(204);


### PR DESCRIPTION
## Summary
- ensure Jest globals are recognized during server linting
- format server and client tests to satisfy Prettier

## Testing
- `cd server && npm test`
- `cd server && npm run lint`
- `cd client && npm test`
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f0b2e64c0832f9073773d1591d03b